### PR TITLE
[Prompt-1] Fixing incorrect language key.

### DIFF
--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -27,7 +27,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 %>
 
 <liferay-ui:search-container
-	emptyResultsMessage="no-web-content-was-foundd"
+	emptyResultsMessage="no-web-content-was-found"
 	id="<%= searchContainerId %>"
 	searchContainer="<%= articleSearchContainer %>"
 >

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.40.0
+version 7.41.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.41.0
+version 7.40.0


### PR DESCRIPTION
- Error :
	In webcontent 
	Expected Result: The message "**No web content was found**" is displayed.
	Actual Result: The message "**no-web-content-was-foundd**" is displayed
- Solution: 
	In module web-experience/jounal/**journal-web** go to META-INF/resource/**view_entries.jsp** file and fix  **"emptyResultsMessage"** property of **<liferay-ui:search-container />** component (at line number 	30).
	+solution 1: change value to expected message (**"No web content was found"**).
	+solution 2: change value to (**"no-web-content-was-found"**)
- Explanation:
	+ **<liferay-ui:search-container />** component belong to liferay-ui taglib, it can create a grid for displaying a list of objects and their properties.
	+ **"emptyResultsMessage"** property is message will be shown when the list empty. It also can load messages (Key-value) in language.properties file.
	+ in solution 1 we hardcode the correct message to this property.it's quick but hard to maintain
	+ with solution 2: I found a language module ("web-experience/journal/journal-lang"). It includes all Language-xx.properties files. In Language.properties already exist a message(**"no-web-content-was-found=No web content was found."**). We can use the key of this message for the **"emptyResultsMessage"** property. It's better than solution 1. It's easy to maintain.
- Learned:
 	+ we should use language. properties to declare some massage or alert,...
 	+ Use the correct key to get the correct value of the message
 	+ If you have many modules and there can have language keys and translations to maintain, and there will probably be duplicate keys. It should use language modules.

	