### PR TITLE
[Prompt-1] Fixing incorrect language key.

### DIFF
--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -24,10 +24,11 @@ SearchContainer articleSearchContainer = journalDisplayContext.getSearchContaine
 String displayStyle = journalDisplayContext.getDisplayStyle();
 
 String searchContainerId = ParamUtil.getString(request, "searchContainerId");
+
 %>
 
 <liferay-ui:search-container
-	emptyResultsMessage="no-web-content-was-foundd"
+	emptyResultsMessage="no-web-content-was-found"
 	id="<%= searchContainerId %>"
 	searchContainer="<%= articleSearchContainer %>"
 >

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.40.0
+version 7.41.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 7.41.0
+version 7.40.0


### PR DESCRIPTION
- Error: The message displayed when web content is empty was wrong
- Resolve: Replace that message in “view_entries.jsp” file by the right message or by the key reference to that message. But in this case, we use a key.
- Explanation: Rather than providing a specific message and display them to a user, we have a key and those keys reside in a language.properties, that make things easier when we modify them.
- How it works: The module’s dependencies specified in build.grade file. In that has a dependency provided by “com.liferay.journal.lang” where has a language.propeties file. At build time, the Grade bundle plugin reads that file and bnd adds the required Import-Package headers to the module JAR’s META-INF/MANIFEST. Then we can use those keys in any JSP file.