### PR TITLE
[Prompt2.2] Fix default number of folders pagination

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -32,8 +32,6 @@ String dlFileEntryTypeName = LanguageUtil.get(request, "basic-document");
 
 int status = WorkflowConstants.STATUS_APPROVED;
 
-int numberItemsShowDelta = 5;
-
 if (permissionChecker.isContentReviewer(user.getCompanyId(), scopeGroupId)) {
 	status = WorkflowConstants.STATUS_ANY;
 }
@@ -55,7 +53,7 @@ portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
 
-SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", numberItemsShowDelta, portletURL, null, null);
+SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", dlPortletInstanceSettings.getEntriesPerPage(), portletURL, null, null);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -32,6 +32,8 @@ String dlFileEntryTypeName = LanguageUtil.get(request, "basic-document");
 
 int status = WorkflowConstants.STATUS_APPROVED;
 
+int numberItemsShowDelta = 5;
+
 if (permissionChecker.isContentReviewer(user.getCompanyId(), scopeGroupId)) {
 	status = WorkflowConstants.STATUS_ANY;
 }
@@ -53,7 +55,7 @@ portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
 
-SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", numberItemsShowDelta, portletURL, null, null);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 


### PR DESCRIPTION
**Error**
-The dlSearchContainer is set the SearchContainer.DEFAULT_DELTA
**Solution**
-Replace SearchContainer.DEFAULT_DELTA by dlPortletInstanceSettings.getEntriesPerPage()
**Explanation**
-The value SearchContainer.DEFAULT_DELTA is 20 so the page will show 20 folders each page, so set it to the dlPortletInstanceSettings.getEntriesPerPage(), this is the value of <select> tag in the configuration.jsp file of the Configuration windows of the Document and Media, then it will change the numbers of folders conforming to the value of <select> tag.