### PR TITLE
[Prompt 2.3] Fix checking tag has already exist when create Web content.

### DIFF
--- a/lib/portal/dependencies.properties
+++ b/lib/portal/dependencies.properties
@@ -186,6 +186,6 @@ xmlsec=org.apache.santuario:xmlsec:1.5.8
 xmpcore=com.adobe.xmp:xmpcore:5.1.2
 xpp3=xpp3:xpp3_min:1.1.4c
 xstream=com.thoughtworks.xstream:xstream:1.4.7
-xuggle-xuggler-noarch=xuggle:xuggle-xuggler:5.2
+xuggle-xuggler-noarch=xuggle:xuggle-xuggler:5.4
 xz=org.tukaani:xz:1.5
 yui-compressor=com.yahoo.platform.yui:yuicompressor:2.4.7

--- a/lib/portal/dependencies.properties
+++ b/lib/portal/dependencies.properties
@@ -186,6 +186,6 @@ xmlsec=org.apache.santuario:xmlsec:1.5.8
 xmpcore=com.adobe.xmp:xmpcore:5.1.2
 xpp3=xpp3:xpp3_min:1.1.4c
 xstream=com.thoughtworks.xstream:xstream:1.4.7
-xuggle-xuggler-noarch=xuggle:xuggle-xuggler:5.4
+xuggle-xuggler-noarch=xuggle:xuggle-xuggler:5.2
 xz=org.tukaani:xz:1.5
 yui-compressor=com.yahoo.platform.yui:yuicompressor:2.4.7

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,6 +122,7 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
+			name = StringUtil.toLowerCase(StringUtil.trim(name));
 			AssetTag tag = fetchTag(group.getGroupId(), name);
 
 			if (tag == null) {


### PR DESCRIPTION
- Error: Create another Web content with the same tags failed to complete.

- Cause: When we click on the **Publish** button, the **checkTags** function will check each tag’s name of the list tags that have already existed in the Database. Specifically, the **fetchTag** function will find each tag by their **groupId** and **name**. If data response is null, it means they do not exist in the database, so they will be added to the memory. Otherwise, the data response is an **AssetTag** type, that tag will be added to the list tags and return to where called it. But the **checkTags** function has a problem in the fetch Tag process. They didn't check the name carefully. That the lower case name has a difference with the upper case name, so the data response will be wrong after fetch. For example, if the “**abc**” tag has already existed in the Database, and then you create new Web content with “**Abc**” tag. During the **checkTags**, it will fetch the tag with the name Abc and absolutely the data response will be null, because “Abc” will be diff from “**abc**”, so they go to create a new Tag with the name “Abc”. But if you go further, you will see inside the **addTag** function has to check tag exists also, but it is better than **checkTags** function that they lower the tag name “**Abc**”, so in this case, “**Abc**” is equal with “**abc**”, so it will throw an exception that **"A tag with the name " + name + " already exists";**  and then lead to failure.

- Solution: in the **checkTags** function, we will fetch tag with their groupId and name after lower it, so that data will respond correctly:   **name = StringUtil.toLowerCase(StringUtil.trim(name));**
