### PR TITLE
[Prompt-2-3] Fixbug add AssetTags in the Basic web content.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,7 +122,7 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
-			AssetTag tag = fetchTag(group.getGroupId(), name);
+			AssetTag tag = fetchTag(group.getGroupId(),  StringUtil.toLowerCase(StringUtil.trim(name)));
 
 			if (tag == null) {
 				ServiceContext serviceContext = new ServiceContext();

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,7 +122,8 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
-			AssetTag tag = fetchTag(group.getGroupId(),  StringUtil.toLowerCase(StringUtil.trim(name)));
+			name = StringUtil.toLowerCase(StringUtil.trim(name));
+			AssetTag tag = fetchTag(group.getGroupId(), name);
 
 			if (tag == null) {
 				ServiceContext serviceContext = new ServiceContext();


### PR DESCRIPTION
- Error
Steps to reproduce
1. Web Content > Add Basic Web Content
2. Copy and paste these tags into the Tags field:
"Redriven,carburized,renotarizing,bumph,englewood,unprotracted,avower,preincorporated,tungsten,sewerage,eulogized,preimpress,vaporetto,provinciality.,Subformation,verbose,epochal,porkpie,haematoid,anticonformity,skagerrak,balding,helot,captor,bwg,repropose,rainlessness,dumps.,Rooter,punishable,florry,overillustrative,nonwatertight,coachwork,consecration,caryophyllaceous,catlin,propublication,jon,miaul,anthophilous,frigidity.,Deracinnating,qualitatively,lanarkshire,breed,ululant,injudicious,scorpionfish,oestrogen,kur,preeternal,noncrystallizable,retardate,sailor,decuple.,Recce,bollix,regeneration,manistee,haematocyte,cynwulf,immaterialise,centricity,stinkeroo,domelike,bighorn,pillarlike,mercaptide,delicious"
3. Press "enter" to add Tags
4. Publish Web Content. Successful publish.
5. Create another web content with the same tags.
6. Publish Web Content.

Expected Results: Successful publish.
Actual Results: Your request failed to complete
- Solution
       In portal-impl goto portlet/asset/service/impl/**AssetTagLocalServiceImpl.java** file
At line 125 change `AssetTag tag = fetchTag(group.getGroupId(), name)` to 
`AssetTag tag = fetchTag(group.getGroupId(),  StringUtil.toLowerCase(StringUtil.trim(name)));`
- Explaination
      + Before explain we see the a`ddTag()` method: 

```
name = StringUtil.toLowerCase(StringUtil.trim(name));
if (hasTag(groupId, name)) {
         throw new DuplicateTagException(
		"A tag with the name " + name + " already exists");
}
```
      + we see before adding the tag's name, It would be handle by some step (lowercase and trim) then it would be check with `hasTag()` method if already exist a exception will be throw.
     + When we add Basis Web Content and tags, the tags would be check by `checkTags()` method. If a tag already exists It will add to Web Content created otherwise it's will be created by `addTag()` method.
     + But `checkTags()` method does not handle the tag's name so we have an error when throw exception.
