### PR TITLE
[Prompt 2.2] Fix configure Maximum entries to Display in Documents and Media portlet

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -53,7 +53,7 @@ portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
 
-SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", dlPortletInstanceSettings.getEntriesPerPage(), portletURL, null, null);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 


### PR DESCRIPTION
- Error: The default results per page and number of the folder displayed do not changed after select value in the Configuration of **Document and Media**.

- Cause: First of all, let's understand the process before fixing this issue. A **SearchContainer** (is Liferay UI components to display data in Grid format and its containing pagination) to view folders were created, and one of the parameters are passed in it is default delta (default folder in per page) and its value is **SearchContainer.DEFAULT_DELTA**, inside **SearchContainer** we have a taglib named **liferay-ui:search-iterator** (Creates a search results page iterator with an optional paginator.) with **searchContainer** attribute (All configurable properties of the search container, and we also have **delta** in it) - where have options, once chose, it saved in an attribute named **"liferay-ui:page-iterator:delta"**. But in the **Configuration** page, **delta** saved in attribute named **"fileEntriesPerPage"** and accessed through **dlPortletInstanceSettings.getEntriesPerPage()**.

- Resolve: So to solve this problem, we just need to pass the delta value in configuration page(**dlPortletInstanceSettings.getEntriesPerPage()**) to that **SearchContainer**, so the number of folders will render up on to which **delta** was chose in configuration page.
