### PR TITLE
[Prompt-3-1] Fixbug NullPointer Frontend Prompt.

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -386,7 +386,7 @@ public class ComboServlet extends HttpServlet {
 
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);
 
-		if (portlet.isUndeployedPortlet()) {
+		if (portlet == null || portlet.isUndeployedPortlet()) {
 			return null;
 		}
 


### PR DESCRIPTION
**- Error :** 
Steps to reproduce the problem:
1. Add a Web Content Display portlet to the homepage.
2. Reload that page.
3. Open dev tools in Chrome and go to the browser Sources tab. Copy the name of a "combo?browserId..." file which includes "JournalContentPortlet_INSTANCE_" in the name.
4. Paste that value into the browser search bar, change the portlet ID "JournalContentPortlet_INSTANCE" by misspelling it, and press enter.
Expected Result: A 404 error will appear as the URL doesn't actually exist.
Actual Result: Internal Server Error 500 will show up and a Null Pointer Exception will appear in the logs.

**- Explanation:**
At line 387, `Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);`
Because of the portletId is wrong so when getPortletById() method call will `return null;`
=> **portlet = null;** and we will have **NullPoiterException** when call `(portlet.isUndeployedPortlet()) `
As the exception stack call, we'll see the exception would be caught by service() method

```
public void service(
			HttpServletRequest request, HttpServletResponse response)
		throws IOException, ServletException {
		try {
			doService(request, response);
		}
		catch (Exception e) {
			_log.error(e, e);

			PortalUtil.sendError(
				HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e, request,
				response);
		}
	}
```

So It's why we have this error.
We can check null before use portlet variable.