### PR TITLE
[Prompt 3.1] Fix handling a 404 error as the URL does not actually exist.

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -386,7 +386,7 @@ public class ComboServlet extends HttpServlet {
 
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);
 
-		if (portlet.isUndeployedPortlet()) {
+		if (portlet == null || portlet.isUndeployedPortlet()) {
 			return null;
 		}
 


### PR DESCRIPTION
- Error: **Internal Server Error 500** shows up and a **Null pointer Exception** appears in the logs as the URL doesn’t actually exist.

- Cause: When the error occurred, a **Null Pointer Exception** will be thrown with information is an error at line: 
                                                       **if (portlet.isUndeployedPortlet())**
After debugging at this line, I found out that the **“portlet”** is null so that is the cause make this code **portlet.isUndeployedPortlet()** throw exception, go further to the function called it, they put it into a try-catch to handle that exception. If an exception happens, they will send an error is **HttpServletResponse.SC_INTERNAL_SERVER_ERROR** with error code 500. But if it does not throw an exception and return null, it will be checked in **doService** function, check if it return null will do **response.setStatus(HttpServletResponse.SC_NOT_FOUND)** - a 404 error. So that's what we expected.

- Resolve: So, to fix that, we have to check it again to make it not throw an exception:
**if ((portlet == null) || portlet.isUndeployedPortlet())**. So it will return null and will be checked in **doService** function.
