### PR TITLE
[Prompt-3-2] Fixbug session popup don't show in second time.

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -505,7 +505,7 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
-									instance._host.extend();
+									host.extend();
 								}
 								else if (!hasExpired) {
 									if (warningMoment) {

--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -505,7 +505,7 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
-									instance._uiSetActivated();
+									instance._host.extend();
 								}
 								else if (!hasExpired) {
 									if (warningMoment) {


### PR DESCRIPTION
- **Error**
Steps to Reproduce:
1. Edit Liferay_home/tomcat/webapps/ROOT/WEB-INF/web.xml and change <session-timeout>30</session-timeout> to <session-timeout>2</session-timeout>
2. Start Liferay session and log in
3. In Control Panel, click on the "Go to Other Site" icon and select the same site (or other site) but make sure it opens to a different tab (or window)
4. Make sure you can see both windows
5. Add Asset Publisher portlet to one of the pages and click to Configuration on the portlet (a configuration page pops up)
6. Wait for session-expiration-warning message to be displayed; it should be displayed on both pages
7. Click to extend the session another 2 minutes on either of the pages; warning message goes away on both pages
8. After another minute or so, the warning message will appear again
Expected Results:Warning message should appear on both windows
Actual Results:Warning message will only appear on the window that extended the session another 2 minutes
- **Explanation:**
 When we click to the Extend button in the warning popup the onClick will be trigger: 

```
on: {
	click: function(event) {
		if (event.domEvent.target.test('.alert-link')) {
			event.domEvent.preventDefault();
			instance._host.extend();
		}
	}
},
```
It's be fired and call the **extend()** method.
The **extend()** method fire a chain of events (sessionStateChange, afterSessionStatgeChange,...)
At the end, it will close the popup and the **resetInterval()** method will be called to reset the process.
The main reason is in another page, the onClick method didn't call and the **extend()** didn't call too.
After popup closed, 
```
if (!hasWarned) {
	instance._uiSetActivated();
}
```
The **_uiSetActivated()** method'll be called and close the popup but It didn't reset the process. So the popup will not so against.
- **Solution:**
We can change **instance._uiSetActivated()**  to **instance._host.extend()** (like within **onClick()** method).
