### PR TITLE
[Prompt 3.1] Fixing the NullPointerException and return the Not found page 404

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -46,6 +46,7 @@ import com.liferay.portal.servlet.filters.dynamiccss.DynamicCSSUtil;
 import com.liferay.portal.util.AggregateUtil;
 import com.liferay.portal.util.PrefsPropsUtil;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.kernel.exception.NoSuchAddressException;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -227,6 +228,8 @@ public class ComboServlet extends HttpServlet {
 							HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
 						response.setStatus(HttpServletResponse.SC_NOT_FOUND);
 
+						PortalUtil.sendError(HttpServletResponse.SC_NOT_FOUND,new NoSuchAddressException(),request,response);
+
 						return;
 					}
 
@@ -386,7 +389,7 @@ public class ComboServlet extends HttpServlet {
 
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);
 
-		if (portlet.isUndeployedPortlet()) {
+		if (portlet == null || portlet.isUndeployedPortlet()) {
 			return null;
 		}
 

--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -227,9 +227,7 @@ public class ComboServlet extends HttpServlet {
 							HttpHeaders.CACHE_CONTROL,
 							HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
 						response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-
-						PortalUtil.sendError(HttpServletResponse.SC_NOT_FOUND,new NoSuchAddressException(),request,response);
-
+git
 						return;
 					}
 


### PR DESCRIPTION
**Error**
-Wrong when misspelling the portletId of the url, the page will return a internal server error and the log shows NullPointerException.
**Solution**
-Check null the portlet when get it in the getResourceRequestDispatcher method.
-After that, return the 404 page of Liferay when the getResourceRequestDispatcher return null by adding this line of code
_PortalUtil.sendError(HttpServletResponse.SC_NOT_FOUND,new NoSuchAddressException(),request,response);_
**Explanation**
-First when load the url containing the misspelling porletId, the service method will try catch the doService method, in the doService method, it performs the getRequestDispatcher method to check the portlet available with the modulePath. But the modulePath have misspelling portletId so the portlet will be null. They forget to check null so when using that portlet to call the portlet.isUndeployedPortlet() it will return error and the service method will catch it and log that NullPoiterExceptionError and direct to the Internal_server_error page of liferay.