### PR TITLE
[Prompt 3.2] Fix display warning message on both windows.

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -505,6 +505,7 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
+									instance._host.extend();
 									instance._uiSetActivated();
 								}
 								else if (!hasExpired) {


### PR DESCRIPTION
- **Error**: The warning message just appeared on the window that has extended time.

- **Cause**: The first time after 2 minutes, the session state changes to “**warn**” and a warning message appears on both windows (assume A and B), when you click **Extend** on window A, it will call **instance._host.extend()** function to change session state to “**active**”, and start time again, during start time stage, it will check that when will display the banner(warning message). Specifically,
else if (hasWarned && !hasExpired && !extend && sessionState != 'warned') {
  instance.warn();

  warningMoment = true;
}
So to display the banner require **sessionState != 'warned'** and 3 other conditions, with window A, click extend will change **sessionState** to “**active**”, so it will go inside that "**if**" and call **instance.warn()** - display warning message. But on window B, you do not click on **Extend**, so **sessionState** is still in “**warn**” state. So it can’t go inside that “**if**” and display a warning message.

- **Resolve**: So like I said above, to fix it, we can either change **sessionState** in window B to “active” or remove **sessionState != 'warned'** condition out of that “**if**” statement block like this **if (hasWarned && !hasExpired && !extend)**. I had tried all that two ways and the result was as we expected.
First solution: after click **Extend** in window A, window B go to **_uiSetActivated**, just do close the banner. So we will extend it in here(I mean change **sessionState** to “**active**”).
Second solution: in the "**if**" statement block, it requires have in warning status. Besides, either the **Extend** button click or not. The banner still closes in two windows, so I think **sessionState != 'warned'** condition is unnecessary.

- **Question**: I have confused with the second one, wether do that will make sense or cause another problem.
