### PR TITLE
[Prompt-4-1]: Check permission before return calendar.

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarServiceImpl.java
@@ -80,12 +80,10 @@ public class CalendarServiceImpl extends CalendarServiceBaseImpl {
 	public Calendar fetchCalendar(long calendarId) throws PortalException {
 		Calendar calendar = calendarPersistence.fetchByPrimaryKey(calendarId);
 
-		if (calendar == null) {
+		if (calendar == null || !CalendarPermission.contains(
+				getPermissionChecker(), calendar, ActionKeys.VIEW)) {
 			return null;
 		}
-
-		CalendarPermission.check(
-			getPermissionChecker(), calendar, ActionKeys.VIEW);
 
 		return calendar;
 	}


### PR DESCRIPTION
- Error: 
"Calendar is temporarily unavailable" message is shown when a user doesn't has permissions to watch a calendar.
1.- Add the calendar portlet to a page.
2.- Create a new Resource by going to the Resource tab and clicking "Add Resource" and naming it "My New Resource" and saving.
3.- Back on the Calendar tab, add the calendar related to that resource on the section "Other calendars" by typing "My New Resource"
4.- Create a new regular user through the Control Panel and add them to the Liferay site under Edit User > Sites.
5.- From the Users and Organization menu, impersonate the regular user on another tab and ensure that the new calendar is shown on the calendar portlet, otherwise repeat step 3 as the regular user so that it appears.
6.- As admin on the Calendar portlet, click on the "My New Resource" calendar arrow, and remove permissions on that calendar to everyone except to owner.
7.- On the other tab impersonating the regular user, revisit the page where the calendar is.

Expected behavior: the "My New Resource" calendar is not shown.
Current behavior:"Calendar is temporarily unavailable" message is shown
- Explanation: 
       + The main reason for this error is we have an exception in` fetchCalendar()` method.
```
public Calendar fetchCalendar(long calendarId) throws PortalException {
		Calendar calendar = calendarPersistence.fetchByPrimaryKey(calendarId);

		if (calendar == null) {
			return null;
		}

		CalendarPermission.check(
			getPermissionChecker(), calendar, ActionKeys.VIEW);

		return calendar;
	}
```
       + The exception'll be thrown by the check() method:
```
public static void check(PermissionChecker permissionChecker, Calendar calendar, String actionId) 
       throws PortalException {
		if (!contains(permissionChecker, calendar, actionId)) {
			throw new PrincipalException();
		}
	}
```
This method checks whether the current user has permission in the calendar by actionId. If not it will throw `PrincipalException()`
exception.
- Solution:
       + We can check the permission of the current user by `contains()` method. It's similar to `check()` method but not thrown any exception instead It's just return true or false.



