### PR TITLE
[Prompt-4-2] Fixbug exposed Server's port Core Prompt.

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4980,18 +4980,25 @@ public class PortalImpl implements Portal {
 		return siteAdministrationURL;
 	}
 
-	@Override
 	public String getSiteAdminURL(
-			Company company, Group group, String ppid,
+			ThemeDisplay themeDisplay, String ppid,
 			Map<String, String[]> params)
-		throws PortalException {
+		throws PortalException{
 
 		StringBundler sb = new StringBundler(7);
 
-		sb.append(
-			getPortalURL(
-				company.getVirtualHostname(), getPortalServerPort(false),
-				false));
+		Group group = themeDisplay.getScopeGroup();
+
+		return sb.append(themeDisplay.getPortalURL())
+				.append(_afterHostname(group, ppid, params))
+				.toString();
+	}
+
+	public StringBundler _afterHostname( Group group, String ppid,
+										Map<String, String[]> params)
+		throws PortalException{
+
+		StringBundler sb = new StringBundler(6);
 
 		sb.append(getPathFriendlyURLPrivateGroup());
 
@@ -5021,7 +5028,24 @@ public class PortalImpl implements Portal {
 
 		sb.append(HttpUtil.parameterMapToString(params, true));
 
-		return sb.toString();
+		return sb;
+	}
+
+
+	@Override
+	public String getSiteAdminURL(
+			Company company, Group group, String ppid,
+			Map<String, String[]> params)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(7);
+
+		return sb.append(getPortalURL(
+					company.getVirtualHostname(),
+					getPortalServerPort(false),
+					false))
+				.append(_afterHostname(group, ppid, params))
+				.toString();
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1080,6 +1080,11 @@ public interface Portal {
 		String portletName);
 
 	public String getSiteAdminURL(
+			ThemeDisplay themeDisplay, String ppid,
+			Map<String, String[]> params)
+		throws PortalException;
+
+	public String getSiteAdminURL(
 			Company company, Group group, String ppid,
 			Map<String, String[]> params)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1750,6 +1750,14 @@ public class PortalUtil {
 	}
 
 	public static String getSiteAdminURL(
+			ThemeDisplay themeDisplay, String ppid,
+			Map<String, String[]> params)
+		throws PortalException {
+
+		return getPortal().getSiteAdminURL(themeDisplay, ppid, params);
+	}
+
+	public static String getSiteAdminURL(
 			Company company, Group group, String ppid,
 			Map<String, String[]> params)
 		throws PortalException {

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -248,7 +248,7 @@
 				return '<%= PropsValues.SESSION_ENABLE_URL_WITH_SESSION_ID ? session.getId() : StringPool.BLANK %>';
 			},
 			getSiteAdminURL: function() {
-				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
+				return '<%= PortalUtil.getSiteAdminURL(themeDisplay, StringPool.BLANK, null) %>';
 			},
 			getSiteGroupId: function() {
 				return '<%= themeDisplay.getSiteGroupId() %>';


### PR DESCRIPTION
- Error:
Set up Liferay to use Apache
Set the portal-ext.properties to:
	web.server.http.port=80
	web.server.https.port=443
	web.server.protocol=https
	portal.proxy.path=/liferay
	redirect.url.ips.allowed=127.0.0.1,SERVER_IP,[the docker's IP]
	(Get the docker ip from ifconfig)
	Start Liferay and navigate to the homepage through [docker's IP]:8080
When the default landing page loads, right-click anywhere on the page and select 'View Page Source.
Search the page for "siteadminurl".

Expected: The application server's port is not exposed.
Actual: The application server's port is exposed.
- Explanation:
     + When i debug I saw the hostname and post will be load and append to URL by:
```
sb.append(getPortalURL(
				company.getVirtualHostname(),
				getPortalServerPort(false),
				false))
```
- Solution:
      + We can create the new method and change it to use `themeDisplay.getPortalURL()`. and to do that we need to inject ThemeDisplay to be one of the parameters.