### PR TITLE
[Prompt 3.2] Fixing the expiration warning do not show in the second …

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -340,7 +340,7 @@ AUI.add(
 									timeOffset = Math.floor((Date.now() - timestamp) / 1000) * 1000;
 
 									elapsed = timeOffset;
-								}
+									}
 								else {
 									timestamp = 'expired';
 								}
@@ -505,6 +505,9 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
+
+									instance.set('sessionState', 'active');
+
 									instance._uiSetActivated();
 								}
 								else if (!hasExpired) {


### PR DESCRIPTION
**Error**
-When click extend in the warning message box on one window, the box will disappear on that one and another windows. But the warning box only appear again on the window which be clicked.
**Solution**
-Set the state all the window to be active.
**Explanation**
-The warning will be appear when the time out and the state of the window is active and change to warn. When we click, the state will change from warn to active. But on the window which is not be clicked, the state is still warn, so when the time out, it will not show the warning message box.