### PR TITLE
[Prompt 4.1] Fixing the exception calender can not show

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/display/context/CalendarDisplayContext.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/display/context/CalendarDisplayContext.java
@@ -47,7 +47,14 @@ public class CalendarDisplayContext {
 		List<Calendar> otherCalendars = new ArrayList<>();
 
 		for (long calendarId : calendarIds) {
-			Calendar calendar = _calendarService.fetchCalendar(calendarId);
+
+			Calendar calendar = null;
+
+			try {
+				calendar = _calendarService.fetchCalendar(calendarId);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
 
 			if (calendar == null) {
 				continue;


### PR DESCRIPTION
**Error**
-When check the permission on the new resource calendar not to show to another site members, the calendar portlet will not show any calendar to those members, also their own calendars.
**Solution**
-Catch the exception of calendarService.fetchCalendar method.
**Explanation**
-When check the permission, the calendarService.fetchCalendar method will throw exception and the process of will not move to below code, which will show the another calendar of the site members. So when catch that exception, the process will continue and it will show another calendar.