### PR TITLE
[Prompt 4.2] Fixing the core server port of getSiteAdminURL method

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4981,6 +4981,51 @@ public class PortalImpl implements Portal {
 	}
 
 	@Override
+	public String getSiteAdminURl(
+		ThemeDisplay themeDisplay, String ppid,
+		Map<String, String[]> params)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(7);
+
+		String hostname = themeDisplay.getPortalURL();
+		hostname = hostname.substring(0,hostname.indexOf(":",hostname.indexOf(":")+1));
+		sb.append(hostname);
+
+		sb.append(getPathFriendlyURLPrivateGroup());
+
+		Group group = themeDisplay.getSiteGroup();
+
+		if ((group != null) && !group.isControlPanel()) {
+			sb.append(group.getFriendlyURL());
+			sb.append(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR);
+		}
+
+		sb.append(GroupConstants.CONTROL_PANEL_FRIENDLY_URL);
+		sb.append(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL);
+
+		if (params != null) {
+			params = new LinkedHashMap<>(params);
+		}
+		else {
+			params = new LinkedHashMap<>();
+		}
+
+		if (Validator.isNotNull(ppid)) {
+			params.put("p_p_id", new String[] {ppid});
+		}
+
+		params.put("p_p_lifecycle", new String[] {"0"});
+		params.put(
+			"p_p_state", new String[] {WindowState.MAXIMIZED.toString()});
+		params.put("p_p_mode", new String[] {PortletMode.VIEW.toString()});
+
+		sb.append(HttpUtil.parameterMapToString(params, true));
+
+		return sb.toString();
+	}
+
+	@Override
 	public String getSiteAdminURL(
 			Company company, Group group, String ppid,
 			Map<String, String[]> params)

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1079,6 +1079,11 @@ public interface Portal {
 		PortletResponse portletResponse, ThemeDisplay themeDisplay,
 		String portletName);
 
+	public String getSiteAdminURl(
+			ThemeDisplay themeDisplay, String ppid,
+			Map<String, String[]> params)
+		throws PortalException;
+
 	public String getSiteAdminURL(
 			Company company, Group group, String ppid,
 			Map<String, String[]> params)

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1749,6 +1749,14 @@ public class PortalUtil {
 			portletResponse, themeDisplay, portletName);
 	}
 
+	public static String getSiteAdminURl(
+		ThemeDisplay themeDisplay, String ppid,
+		Map<String, String[]> params)
+		throws PortalException{
+
+		return getPortal().getSiteAdminURl(themeDisplay,ppid,params);
+	}
+
 	public static String getSiteAdminURL(
 			Company company, Group group, String ppid,
 			Map<String, String[]> params)

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -248,7 +248,7 @@
 				return '<%= PropsValues.SESSION_ENABLE_URL_WITH_SESSION_ID ? session.getId() : StringPool.BLANK %>';
 			},
 			getSiteAdminURL: function() {
-				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
+				return '<%= PortalUtil.getSiteAdminURl(themeDisplay, StringPool.BLANK, null) %>';
 			},
 			getSiteGroupId: function() {
 				return '<%= themeDisplay.getSiteGroupId() %>';


### PR DESCRIPTION
**Error**
-The getSiteAdminURL in the page source exposes the port.
**Solution**
-Write another getSiteAdminURL to show exactly the URL without port by substring it.
**Explaination**
-The HostName in the getSiteAdminURL is call by the getPortalURL method of the Portal class which show wrong. So we will use the getPortalURL method of the ThemeDisplay class in the new getSiteAdminURL of my own and combine substring the port to show the true url.   