### PR TITLE
[Prompt 4.1] Fix calendar permission.

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarServiceImpl.java
@@ -84,8 +84,13 @@ public class CalendarServiceImpl extends CalendarServiceBaseImpl {
 			return null;
 		}
 
-		CalendarPermission.check(
-			getPermissionChecker(), calendar, ActionKeys.VIEW);
+		try {
+			CalendarPermission.check(
+				getPermissionChecker(), calendar, ActionKeys.VIEW);
+		}
+		catch (Exception e) {
+			return null;
+		}
 
 		return calendar;
 	}


### PR DESCRIPTION
**- Error:** "Calendar is temporarily unavailable" message is shown when the user has no permission.

**- Cause:** A user after access the calendar will be checked that they have permission for that calendar by **check** function, if they do not, this function will throw an exception and lead to this issue happening.

**- Resolve:** Handle that exception by return null if an exception happens, so that calendar will not add to the list and then do not show to the user.
