### PR TITLE
[Prompt 4.2] Fix the application server's port is exposed.

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4982,6 +4982,18 @@ public class PortalImpl implements Portal {
 
 	@Override
 	public String getSiteAdminURL(
+		ThemeDisplay themeDisplay, String ppid,
+		Map<String, String[]> params)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(7);
+
+		sb.append(themeDisplay.getPortalURL());
+		return getSiteAdminURL(sb, themeDisplay.getScopeGroup(), ppid, params);
+	}
+
+	@Override
+	public String getSiteAdminURL(
 			Company company, Group group, String ppid,
 			Map<String, String[]> params)
 		throws PortalException {
@@ -4992,6 +5004,13 @@ public class PortalImpl implements Portal {
 			getPortalURL(
 				company.getVirtualHostname(), getPortalServerPort(false),
 				false));
+		return getSiteAdminURL(sb, group, ppid, params);
+
+	}
+
+	public String getSiteAdminURL(StringBundler sb, Group group, String ppid,
+					   Map<String, String[]> params)
+		throws PortalException {
 
 		sb.append(getPathFriendlyURLPrivateGroup());
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1084,6 +1084,11 @@ public interface Portal {
 			Map<String, String[]> params)
 		throws PortalException;
 
+	public String getSiteAdminURL(
+		ThemeDisplay themeDisplay, String ppid,
+		Map<String, String[]> params)
+		throws PortalException;
+
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #getSiteAdminURL(Company,
 	 *             Group, String, Map)}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1757,6 +1757,14 @@ public class PortalUtil {
 		return getPortal().getSiteAdminURL(company, group, ppid, params);
 	}
 
+	public static String getSiteAdminURL(
+		ThemeDisplay themeDisplay, String ppid,
+		Map<String, String[]> params)
+		throws PortalException {
+
+		return getPortal().getSiteAdminURL(themeDisplay, ppid, params);
+	}
+
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #getSiteAdminURL(Company,
 	 *             Group, String, Map)}

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -248,7 +248,7 @@
 				return '<%= PropsValues.SESSION_ENABLE_URL_WITH_SESSION_ID ? session.getId() : StringPool.BLANK %>';
 			},
 			getSiteAdminURL: function() {
-				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
+				return '<%= PortalUtil.getSiteAdminURL(themeDisplay, StringPool.BLANK, null) %>';
 			},
 			getSiteGroupId: function() {
 				return '<%= themeDisplay.getSiteGroupId() %>';


### PR DESCRIPTION
- Error: The application server’s port is exposed.

- Cause: Each HTTP/HTTPS request will hit our host server. The host server will use Reverse Proxy to pass communication to the selected container. To make it simpler, we’ll also map 80 host’s port to 80 container’s port, and 443 host’s port to 443 container’s port. And then we configured apache on a host as a proxy and redirect HTTP and HTTPS to mapped ports. In this case, with 80 and 443 port, I redirect it to http://[IPAddress]:8080/ (the IPAddress can be either your machine’s IPAddress or 127.0.0.1 - localhost or 172.17.0.1). To bind the Docker container port 80 to the host system port 8080 and IP address - where our application service (liferay-portal) is running. So if we get a server name from our host system, it’ll expose the port.

- Resolve: I created a new API to get portal URL from remote host instead of host.
