### PR TITLE
[Prompt-5]: Fixbug check wrong permission in workflow task.

### DIFF
--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
@@ -36,25 +36,25 @@ public class WorkflowTaskPermissionChecker {
 			return true;
 		}
 
-		if (!permissionChecker.isContentReviewer(
-				permissionChecker.getCompanyId(), groupId)) {
-
-			return false;
-		}
-
 		long[] roleIds = permissionChecker.getRoleIds(
 			permissionChecker.getUserId(), groupId);
 
 		for (WorkflowTaskAssignee workflowTaskAssignee :
-				workflowTask.getWorkflowTaskAssignees()) {
+			workflowTask.getWorkflowTaskAssignees()) {
 
 			if (isWorkflowTaskAssignableToRoles(
-					workflowTaskAssignee, roleIds) ||
+				workflowTaskAssignee, roleIds) ||
 				isWorkflowTaskAssignableToUser(
 					workflowTaskAssignee, permissionChecker.getUserId())) {
 
 				return true;
 			}
+		}
+
+		if (!permissionChecker.isContentReviewer(
+				permissionChecker.getCompanyId(), groupId)) {
+
+			return false;
 		}
 
 		return false;

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
@@ -123,8 +124,12 @@ public class MyWorkflowTaskPortlet extends MVCPortlet {
 			WorkflowTask workflowTask, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		long groupId = MapUtil.getLong(
+			workflowTask.getOptionalAttributes() , "groupId",
+			themeDisplay.getSiteGroupId());
+
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
+				groupId, workflowTask,
 				themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(


### PR DESCRIPTION
- Error 1:
Steps to Reproduce using a User with Site Content Reviewer role:
1. Add a new Site "My Site"
2. Add a new User
3. Add User to "My Site"
4. Assign roles: Site Administration and Site Content Reviewer
5. Save User
6. Log in as the new User
7. Go to "My Site"
8. In "My Site" go to Configuration > Workflow Configuration
9. Set Single Approver for Calendar
10. Add a Calendar portlet to a page
11. Add an event > Submit for Publication
12. Go to My Account > Notifications
13. Click on Calendar notification message
      + Expected Result: User is navigated to My Workflow Tasks portlet to view workflow submission.
      + Actual Result: The User cannot access My Workflow Tasks portlet. If you navigate back to My Account > My Workflow Tasks > Assigned to My Roles, you are able to access My Workflow Tasks portlet and assign/approve workflow submission but still not view it.
- Explanation:
When we create a new site, we'll have a new record in **Group_** table in DB (database) and Assign roles: Site Administration and Site Content Reviewer will create 2 records in **UserGroupRole** table with 2 new records with (UserId, GroupId, RoleId, ...)
When I debug, I saw the 
`hasPermission(long groupId, WorkflowTask workflowTask,PermissionChecker permissionChecker)` method will be called.
But the groupId which we assign to this method wrong( It's not the same as the site we created and assign a role).
And I found the right groupId in the **workflowtask** object. 


- Error 2: 
Steps to Reproduce as a User with view permissions:
1. Define the following User role permissions in the Roles portlet
	a. Dynamic Data Lists Record Set: Add Record
	b. Dynamic Data Lists Record Set: Update
	c. Dynamic Data Lists Record Set: View
	d. My Workflow Tasks: Access in My Account
	e. My Workflow Tasks: View
	f. General Permissions: View Control Panel
2. Add a new User with the above role
3. Add DDL Display to a page, then add the "To Do" definition from the display Add button
4. Select Single Approver workflow > Save
5. Log in as the new User
6. Submit a DDL record for publication (attachment not necessary)
7. Log in as Test Test
8. Go to Notifications and select the DDL record submission
9. Assign it to yourself
10. Reject DDL record submission
11. Log in as the new User
12. Go to My Workflow Tasks > Click into rejected DDL record to view details
Expected Result: User is able to view DDL record details.
Actual Result: User gets a permissions error message.

- Explanation: 
Becuase this error is the same place with the previous error. So I found in the method:

```
public boolean hasPermission(
		long groupId, WorkflowTask workflowTask,
		PermissionChecker permissionChecker) {

		if (permissionChecker.isOmniadmin() ||
			permissionChecker.isCompanyAdmin()) {

			return true;
		}

		if (!permissionChecker.isContentReviewer(
				permissionChecker.getCompanyId(), groupId)) {

			return false;
		}

		long[] roleIds = permissionChecker.getRoleIds(
			permissionChecker.getUserId(), groupId);

		for (WorkflowTaskAssignee workflowTaskAssignee :
				workflowTask.getWorkflowTaskAssignees()) {

			if (isWorkflowTaskAssignableToRoles(
					workflowTaskAssignee, roleIds) ||
				isWorkflowTaskAssignableToUser(
					workflowTaskAssignee, permissionChecker.getUserId())) {

				return true;
			}
		}

		return false;
	}
```
we'll see **permissionChecker.isContentReviewer()** will be called in the second and because of in this error we didn't set ContentReviewer permission so it'll return false and not check the below. So we can move this method at the end to fix this bug.
