### PR TITLE
[Prompt 5] Fix Workflow Permissions Forms and Workflow Prompt

### DIFF
--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
@@ -36,25 +36,24 @@ public class WorkflowTaskPermissionChecker {
 			return true;
 		}
 
-		if (!permissionChecker.isContentReviewer(
-				permissionChecker.getCompanyId(), groupId)) {
-
-			return false;
-		}
-
 		long[] roleIds = permissionChecker.getRoleIds(
 			permissionChecker.getUserId(), groupId);
 
 		for (WorkflowTaskAssignee workflowTaskAssignee :
-				workflowTask.getWorkflowTaskAssignees()) {
+			workflowTask.getWorkflowTaskAssignees()) {
 
 			if (isWorkflowTaskAssignableToRoles(
-					workflowTaskAssignee, roleIds) ||
+				workflowTaskAssignee, roleIds) ||
 				isWorkflowTaskAssignableToUser(
 					workflowTaskAssignee, permissionChecker.getUserId())) {
 
 				return true;
 			}
+		}
+
+		if (!permissionChecker.isContentReviewer(
+				permissionChecker.getCompanyId(), groupId)) {
+			return false;
 		}
 
 		return false;

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
@@ -40,6 +40,7 @@ import javax.portlet.Portlet;
 import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -124,7 +125,7 @@ public class MyWorkflowTaskPortlet extends MVCPortlet {
 		throws PortalException {
 
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
+			MapUtil.getLong(workflowTask.getOptionalAttributes(), "groupId"), workflowTask,
 				themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(


### PR DESCRIPTION
**1. User with Site Content Reviewer role:**
**- Error:** The user cannot access My Workflow Tasks portlet. 

**- Cause:** During reproduction, after creating a new Site name **“My Site”** and add user in it, the user will be assigned to roles: **Site Administration** and **Site Content Reviewer** - which can help them access and view that portlet. So we have userId with those roles that can access this scope group (**“My site”**). Let them can access to that portlet, they have to go through a **hasPermission** function to check that whether there exists a user with these roles can access that scope group (**“My Site”**). But, they passed the wrong groupId parameter in that function. That groupId defined Control Panel, but the right one we want is groupId of **“My Site”**.

**- Resolve:** Replace that the wrong groupId parameter with the right one was stored in workfowTask attribute.

**2. User with role permissions in the Riles portlet:**
**- Error:** User gets a permission error message when trying to view DDL record details.

**- Cause:** So let the user view DDL record details, they must have **View** and **Access in My Account** permissions in My Workflow Tasks. And to check it they also go through **hasPermission** function. Explain a little bit about this function step by step:
Check is admin or company admin -> return true;
Check is content reviewer -> return false
Check is workflow task assignee to user -> return true
This issue we need to check the third one, they don’t need to have a **Site Content Reviewer** permission to access, so when it comes to checking the second one, it will return false and can’t go to check the third one then lead us to this issue.

**- Resolve:** Swap positions of the second and third one for each other, so we’ll fix this issue and not affect the issue above.
