### PR TITLE
[Prompt 5] Fixing the workflow

### DIFF
--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
@@ -36,6 +36,12 @@ public class WorkflowTaskPermissionChecker {
 			return true;
 		}
 
+		//prompt 5 second issue
+		if(workflowTask.getAssigneeUserId() == permissionChecker.getUserId()){
+
+			return true;
+		}
+
 		if (!permissionChecker.isContentReviewer(
 				permissionChecker.getCompanyId(), groupId)) {
 

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
@@ -29,10 +29,12 @@ import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
 import com.liferay.portal.workflow.task.web.configuration.WorkflowTaskWebConfiguration;
 import com.liferay.portal.workflow.task.web.permission.WorkflowTaskPermissionChecker;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.io.IOException;
 
 import java.util.Map;
+import java.lang.Long;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -123,8 +125,10 @@ public class MyWorkflowTaskPortlet extends MVCPortlet {
 			WorkflowTask workflowTask, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		long groupId = MapUtil.getLong(workflowTask.getOptionalAttributes(),"groupId");  //prompt 5 first issue
+
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
+				groupId, workflowTask,
 				themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(


### PR DESCRIPTION
**_#first issue_**
**Error**
-When click on Calendar notification message of a site using New User, we will get permission error.
**Solution**
-Set the true groupId for the _workflowTaskPermissionChecker.hasPermission
**Explanation**
-At first, they use the themeDisplay.groupId, it is the groupId of the Control Pannel, not the groupId of this workflow, so when checkPermission, it will return false, and we will get the error. So change the to the groupId of this workflow, it will be true.

**_#second issue_**
**Error**
-When click on record of Workflow Tasks after that record was rejected by the Admin, we will get permission error. 
**Solution**
-Check the UserId and the AssigneeUserId of that workflow.
**Explanation**
-When check the permission, the recent UserId doesn't have the Content reviewer permission, so it will return false and we will get the error. So we have to check with AssigneeUserId, if they are equal it will return true, and we can view the record, if not it will return the error as usual.
