### PR TITLE
[Prompt-1] Fixing incorrect language key.

### DIFF
--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -27,7 +27,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 %>
 
 <liferay-ui:search-container
-	emptyResultsMessage="no-web-content-was-foundd"
+	emptyResultsMessage="no-web-content-was-found"
 	id="<%= searchContainerId %>"
 	searchContainer="<%= articleSearchContainer %>"
 >


### PR DESCRIPTION
Hi @binhtran92,
Please help me double-check this PR.

Steps to Reproduce:

1. Start up the portal and log in as anAdministrator.
2. Go to the Control Panel -> Content -> Web Content. Make sure there is no Web Content or
Folders.

Expected Result: The message "No web content was found" is displayed.
Actual Result: The message "no-web-content-was-foundd" is displayed

ROOT CAUSE: In the view_entries.jsp of web-experience content module, one of the attributes of the search container is using a misspelled word.
SOLUTION: I just correct the spelling for this attribute which I mentioned in ROOT CAUSE
Thank you!
