### PR TITLE
[Prompt 2.1] Fix bug Document and Media pagination

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -41,6 +41,8 @@ String tagName = ParamUtil.getString(request, "tag");
 
 boolean useAssetEntryQuery = (categoryId > 0) || Validator.isNotNull(tagName);
 
+int entriesPerPage = dlPortletInstanceSettings.getEntriesPerPage();
+
 DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletInstanceSettingsHelper(dlRequestHelper);
 
 String displayStyle = GetterUtil.getString((String)request.getAttribute("view.jsp-displayStyle"));
@@ -53,7 +55,7 @@ portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
 
-SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", entriesPerPage, portletURL, null, null);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 


### PR DESCRIPTION
Hi @binhtran92,
Please help me double-check this PR.
Steps to reproduce:
1. Add a Documents and Media portlet.
2. Add 7 folders in the DM porlet.
3. Click the configuration of DM.
4. Select 5 of "Maximum Entries to Display "
5. Click Save and refresh the page.

Expected result:
The default results per page is 5 and 5 folders are displayed.

Actual result:
The default results per page and number of folder displayed does not changed.

ROOT CAUSE: In modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp  file using non-dynamic number (SearchContainer.DEFAULT_DELTA ) for entries to be shown, this value always is 20. That reason why the number of entries kept unchanged.

SOLUTION: Replace SearchContainer.DEFAULT_DELTA  with  dlPortletInstanceSettings.getEntriesPerPage(), this attribute hold  the value of entries per page.

Thank you!
Viet Hoang