### PR TITLE
[Prompt 2.2] Debug Document and Media folder name 

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -503,7 +503,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									actionJspServletContext="<%= application %>"
 									resultRow="<%= row %>"
 									rowChecker="<%= entriesChecker %>"
-									text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+									text="<%= curFolder.getName() %>"
 									url="<%= rowURL.toString() %>"
 								>
 									<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
@@ -135,7 +135,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 						actionJsp='<%= dlPortletInstanceSettingsHelper.isShowActions() ? "/document_library/folder_action.jsp" : StringPool.BLANK %>'
 						actionJspServletContext="<%= application %>"
 						resultRow="<%= row %>"
-						text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+						text="<%= curFolder.getName() %>"
 						url="<%= viewFolderURL %>"
 					>
 						<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
@@ -65,7 +65,7 @@ SearchContainer searchContainer = new GroupSearch(liferayPortletRequest, iterato
 			<liferay-ui:search-container-column-text colspan="<%= 3 %>">
 				<liferay-frontend:horizontal-card
 					resultRow="<%= row %>"
-					text="<%= HtmlUtil.escape(curGroup.getDescriptiveName(locale)) %>"
+					text="<%= curGroup.getDescriptiveName(locale) %>"
 					url="<%= viewGroupURL.toString() %>"
 				>
 					<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -315,7 +315,7 @@ if (Validator.isNotNull(keywords)) {
 									<liferay-ui:search-container-column-text colspan="<%= 3 %>">
 										<liferay-frontend:horizontal-card
 											resultRow="<%= row %>"
-											text="<%= HtmlUtil.escape(folder.getName()) %>"
+											text="<%= folder.getName() %>"
 											url="<%= viewFolderURL.toString() %>"
 										>
 											<liferay-frontend:horizontal-card-col>

--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -378,7 +378,7 @@ if (portletTitleBasedNavigation) {
 
 												<div class="col-md-4">
 													<liferay-frontend:horizontal-card
-														text="<%= HtmlUtil.escape(fileEntry.getTitle()) %>"
+														text="<%= fileEntry.getTitle() %>"
 														url="<%= rowURL %>"
 													>
 														<liferay-frontend:horizontal-card-col>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_attachments.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_attachments.jsp
@@ -41,7 +41,7 @@ if (kbArticle != null) {
 
 				<div class="col-md-4">
 					<liferay-frontend:horizontal-card
-						text="<%= HtmlUtil.escape(fileEntry.getTitle()) %>"
+						text="<%= fileEntry.getTitle() %>"
 						url="<%= rowURL %>"
 					>
 						<liferay-frontend:horizontal-card-col>

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -298,7 +298,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 								actionJspServletContext="<%= application %>"
 								resultRow="<%= row %>"
 								rowChecker="<%= articleSearchContainer.getRowChecker() %>"
-								text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+								text="<%= curFolder.getName() %>"
 								url="<%= rowURL.toString() %>"
 							>
 								<liferay-frontend:horizontal-card-col>

--- a/modules/apps/web-experience/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/web-experience/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -184,7 +184,7 @@ renderResponse.setTitle(trashRenderer.getTitle(locale));
 											actionJsp="/view_content_action.jsp"
 											actionJspServletContext="<%= application %>"
 											resultRow="<%= row %>"
-											text="<%= HtmlUtil.escape(curTrashRenderer.getTitle(locale)) %>"
+											text="<%= curTrashRenderer.getTitle(locale) %>"
 											url="<%= rowURL.toString() %>"
 										>
 										</liferay-frontend:horizontal-card>


### PR DESCRIPTION
Hi @binhtran92 ,
Please double-check this PR for me.
Steps to Reproduce
1. Add a Documents and Media portlet to a page.
2. Create a new Document Folder with an Ampersand in the folder's name.
3. Set the Documents and Media portlet to Icon view.

Expected:
Ampersand will display correctly.
Actual:
Ampersand displays as its escaped version instead.

ROOT CAUSE: In each file below, they are using frontend-taglib/horizontal-card to render components horizontally, and the text is being escaped. But if you see in file _modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/horizontal_card/page.jsp_  you will see the text is escaped already.

- modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
- modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/view_images.jsp
- modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/group_selector/page.jsp
- modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
- modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
- modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/article_attachments.jsp
- modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
- modules/apps/web-experience/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp

SOLUTION: Remove HtmlUtil.escape() redundancy.

Thank you!
Viet Hoang 