### PR TITLE
[Prompt 2.3] Web-content tag 

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,6 +122,7 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
+			name = StringUtil.toLowerCase(StringUtil.trim(name));
 			AssetTag tag = fetchTag(group.getGroupId(), name);
 
 			if (tag == null) {


### PR DESCRIPTION
Hi @binhtran92,
Please double-check thís PR for me.
Steps to Reproduce
1. Web Content > Add Basic Web Content
2. Copy and paste these tags into the Tags field:
"Redriven,carburized,renotarizing,bumph,englewood,unprotracted,avower,preincorporated,tungsten,sewerage,eulogized,preimpress,vaporetto,provinciality.,
Subformation,verbose,epochal,porkpie,haematoid,anticonformity,skagerrak,balding,helot,captor,bwg,repropose,rainlessness,dumps.,Rooter,punishable,florry,
overillustrative,nonwatertight,coachwork,consecration,caryophyllaceous,catlin,propublication,jon,miaul,anthophilous,frigidity.,Deracinnating,qualitatively,
lanarkshire,breed,ululant,injudicious,scorpionfish,oestrogen,kur,preeternal,noncrystallizable,retardate,sailor,decuple.,Recce,bollix,regeneration,manistee,
haematocyte,cynwulf,immaterialise,centricity,stinkeroo,domelike,bighorn,pillarlike,mercaptide,delicious"
3. Press "enter" to add Tags
4. Publish Web Content. Successful publish.
5. Create another web content with the same tags.
6. Publish Web Content.

Results of Testing
Expected Results: Successful publish.
Actual Results: Your request failed to complete.

ROOT CAUSE: During the period I debug, I tried with tags "carburized, renotarizing" and feature work but when I tried with "Carburized, Renotarizing"  it put an error. So I think to have something different between uppercase and lowercase letters. 
when we add new tags fetch function will compare new tags and tags exist, if already exist, add function will fetch them from DB.
However, when tags are saved into DB, it has been converted to lowercase. With tags that have uppercase already exist in DB, **checkTags** function return it already exist in DB, but fetch func can't be found in DB cause **checkTags** func didn't convert to lowercase. That reason for this error.

SOLUTION: Add convert tag to lowercase into **checkTags** function.

Thank you!
Viet Hoang