### PR TITLE
[Prompt 3.1] Debug front-end null pointer

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -386,7 +386,7 @@ public class ComboServlet extends HttpServlet {
 
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);
 
-		if (portlet.isUndeployedPortlet()) {
+		if (portlet == null || portlet.isUndeployedPortlet()) {
 			return null;
 		}
 


### PR DESCRIPTION
Hi @binhtran92,
Please double-check this PR for me.
Steps to reproduce the problem:

1. Add a Web Content Display portlet to the homepage.
2. Reload that page.
3. Open dev tools in Chrome and go to the browser Sources tab. Copy the name of a "combo?browserId..." file which includes "JournalContentPortlet_INSTANCE_" in the name.
4. Paste that value into the browser search bar, change the portlet ID "JournalContentPortlet_INSTANCE" by misspelling it and press enter.

Expected Result: A 404 error will appear as the URL doesn't actually exist.

Actual Result: Internal Server Error 500 will show up and a Null Pointer Exception will appear in the logs.

ROOT CAUSE: You can see in terminal log the error at com.liferay.portal.servlet.ComboServlet.getResourceRequestDispatcher(ComboServlet.java:389) file (portal-impl/src/com/liferay/portal/servlet/ComboServlet.java) used to check portlet whether deployed or not. But if the portlet does not exist, there is an error throwing an exception, that reason for this error.

SOLUTION: We need to add check null for portlet before calling isUndeployedPortlet() method of portlet.

Thank you!
Viet Hoang
