### PR TITLE
[Prompt 3.2] Debug prompt frontend  session expriration

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -505,7 +505,7 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
-									instance._uiSetActivated();
+									host.extend();
 								}
 								else if (!hasExpired) {
 									if (warningMoment) {


### PR DESCRIPTION
Hi @binhtran92,
Please double-check this PR for me.
Steps to reproduce the problem:
1. Edit Liferay_home/tomcat/webapps/ROOT/WEB-INF/web.xml and change <session-timeout>30</session-timeout> to <session-timeout>2</session-timeout>
2. Start Liferay session and log in
3. In Control Panel, click on the "Go to Other Site" icon and select the same site (or other site) but make sure it opens to a different tab (or window)
4. Make sure you can see both windows
5. Add Asset Publisher portlet to one of the pages and click to Configuration on the portlet (a configuration page pops up)
6. Wait for session-expiration-warning message to be displayed; it should be displayed on both pages
7. Click to extend the session another 2 minutes on either of the pages; warning message goes away on both pages
8. After another minute or so, the warning message will appear again

Expected Results:
Warning message should appear on both windows

Actual Results:
Warning message will only appear on the window that extended the session another 2 minutes

ROOT CAUSE: in file session.js, I see it create an interval every 1s to check the session time from cookie has hasExpired or hasWarned then change sessionState accordingly. if the sessionState is warned _onHostSessionStateChange will call → _beforeHostWarned to change the site title, open warning popup count down the time left. When we click extend the sessionState should be active on all the tabs. But in other tabs, interval only call func instance._uiSetActivated() in line 508  to close the banner, unRegisterInterval and host sessionState still warned after cookie change.

SOLUTION: My solution is instead instance._uiSetActivated() by host.extend() to set the sessionState to active after extended process.

Thank you!
Viet Hoang