### PR TITLE
 [PROMPT4.1] core permission

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/display/context/CalendarDisplayContext.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/display/context/CalendarDisplayContext.java
@@ -47,7 +47,14 @@ public class CalendarDisplayContext {
 		List<Calendar> otherCalendars = new ArrayList<>();
 
 		for (long calendarId : calendarIds) {
-			Calendar calendar = _calendarService.fetchCalendar(calendarId);
+			Calendar calendar = null;
+
+			try {
+				calendar = _calendarService.fetchCalendar(calendarId);
+			}
+			catch (PortalException pe) {
+				continue;
+			}
 
 			if (calendar == null) {
 				continue;


### PR DESCRIPTION
Hi @binhtran92 ,
Please review this PR for me and leave your comments.
Steps to reproduce:
"Calendar is temporarily unavailable" message is shown when a user doesn't has permissions to watch a calendar.
1.- Add the calendar portlet to a page.
2.- Create a new Resource by going to the Resource tab and clicking "Add Resource" and naming it "My New Resource" and saving.
3.- Back on the Calendar tab, add the calendar related to that resource on the section "Other calendars" by typing "My New Resource"
4.- Create a new regular user through the Control Panel and add them to the Liferay site under Edit User > Sites.
5.- From the Users and Organization menu, impersonate the regular user on another tab and ensure that the new calendar is shown on the calendar portlet, otherwise repeat step 3 as the regular user so that it appears.
6.- As admin on the Calendar portlet, click on the "My New Resource" calendar arrow, and remove permissions on that calendar to everyone except to owner.
7.- On the other tab impersonating the regular user, revisit the page where the calendar is.

Expected behavior: the "My New Resource" calendar is not shown.
Current behavior: "Calendar is temporarily unavailable" message is shown

Follow the log terminal I see the error at CalendarDisplayContext.getOtherCalendars(CalendarDisplayContext.java:50) and CalendarPermission.check(CalendarPermission.java:38). I see that the permission exception throws while fetching others calendars. So I used try-catch block at the CalendarDisplayContext .

Thank you.
Viet Hoang