### PR TITLE
[PROMPT4.2] CORE-SERVER-PORT

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4993,35 +4993,7 @@ public class PortalImpl implements Portal {
 				company.getVirtualHostname(), getPortalServerPort(false),
 				false));
 
-		sb.append(getPathFriendlyURLPrivateGroup());
-
-		if ((group != null) && !group.isControlPanel()) {
-			sb.append(group.getFriendlyURL());
-			sb.append(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR);
-		}
-
-		sb.append(GroupConstants.CONTROL_PANEL_FRIENDLY_URL);
-		sb.append(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL);
-
-		if (params != null) {
-			params = new LinkedHashMap<>(params);
-		}
-		else {
-			params = new LinkedHashMap<>();
-		}
-
-		if (Validator.isNotNull(ppid)) {
-			params.put("p_p_id", new String[] {ppid});
-		}
-
-		params.put("p_p_lifecycle", new String[] {"0"});
-		params.put(
-			"p_p_state", new String[] {WindowState.MAXIMIZED.toString()});
-		params.put("p_p_mode", new String[] {PortletMode.VIEW.toString()});
-
-		sb.append(HttpUtil.parameterMapToString(params, true));
-
-		return sb.toString();
+		return _getSiteAdminURL(sb, group, ppid, params);
 	}
 
 	/**
@@ -5038,6 +5010,18 @@ public class PortalImpl implements Portal {
 			group.getCompanyId());
 
 		return getSiteAdminURL(company, group, ppid, params);
+	}
+	@Override
+	public String getSiteAdminURL(
+		String portalURL, Group group, String ppid,
+		Map<String, String[]> params)
+		throws PortalException {
+
+		StringBundler sb = new StringBundler(7);
+
+		sb.append(portalURL);
+
+		return _getSiteAdminURL(sb, group, ppid, params);
 	}
 
 	/**
@@ -8635,6 +8619,40 @@ public class PortalImpl implements Portal {
 		catch (Exception e) {
 			return layout.getGroupId();
 		}
+	}
+	private String _getSiteAdminURL(
+		StringBundler sb, Group group, String ppid,
+		Map<String, String[]> params) {
+
+		sb.append(getPathFriendlyURLPrivateGroup());
+
+		if ((group != null) && !group.isControlPanel()) {
+			sb.append(group.getFriendlyURL());
+			sb.append(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR);
+		}
+
+		sb.append(GroupConstants.CONTROL_PANEL_FRIENDLY_URL);
+		sb.append(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL);
+
+		if (params != null) {
+			params = new LinkedHashMap<>(params);
+		}
+		else {
+			params = new LinkedHashMap<>();
+		}
+
+		if (Validator.isNotNull(ppid)) {
+			params.put("p_p_id", new String[] {ppid});
+		}
+
+		params.put("p_p_lifecycle", new String[] {"0"});
+		params.put(
+			"p_p_state", new String[] {WindowState.MAXIMIZED.toString()});
+		params.put("p_p_mode", new String[] {PortletMode.VIEW.toString()});
+
+		sb.append(HttpUtil.parameterMapToString(params, true));
+
+		return sb.toString();
 	}
 
 	private Group _getSiteGroup(long groupId) throws PortalException {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1093,6 +1093,10 @@ public interface Portal {
 			Group group, String ppid, Map<String, String[]> params)
 		throws PortalException;
 
+	public String getSiteAdminURL(
+		String portalURL, Group group, String ppid,
+		Map<String, String[]> params)
+		throws PortalException;
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link
 	 *             #getCurrentAndAncestorSiteGroupIds(long)}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1757,6 +1757,14 @@ public class PortalUtil {
 		return getPortal().getSiteAdminURL(company, group, ppid, params);
 	}
 
+	public static String getSiteAdminURL(
+		String portalURL, Group group, String ppid,
+		Map<String, String[]> params)
+		throws PortalException {
+
+		return getPortal().getSiteAdminURL(portalURL, group, ppid, params);
+	}
+
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #getSiteAdminURL(Company,
 	 *             Group, String, Map)}

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -248,7 +248,7 @@
 				return '<%= PropsValues.SESSION_ENABLE_URL_WITH_SESSION_ID ? session.getId() : StringPool.BLANK %>';
 			},
 			getSiteAdminURL: function() {
-				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
+				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getPortalURL(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
 			},
 			getSiteGroupId: function() {
 				return '<%= themeDisplay.getSiteGroupId() %>';


### PR DESCRIPTION
Hi @binhtran92 ,
Please review this PR for Prompt 4.2 core-server-port.
Steps to Reproduce:
1. Set up apache
	I used docker: https://grow.liferay.com/share/Docker+Scripts
2. Set up Liferay to use Apache
	Set the portal-ext.properties to:
	web.server.http.port=80
	web.server.https.port=443
	web.server.protocol=https
	portal.proxy.path=/liferay
	redirect.url.ips.allowed=127.0.0.1,SERVER_IP,[the docker's IP]
	(Get the docker ip from ifconfig)
	Start Liferay and navigate to the homepage through [docker's IP]:8080
3. When the default landing page loads, right click anywhere on the page and select 'View Page Source'.
4. Search the page for "siteadminurl".

Expected:
The application server's port is not exposed.
Actual:
The application server's port is exposed.

- I found in top_js.jsp file, the getSiteAdminUrl function return 
return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
- At PortalUtil class, it calls method getSiteAdminURL of Portal interface
PortalImpl implement Portal interface and override this method.
- I have checked some other functions like getLayoutUrl the portal URL get from ThemDisplay, it will show the IP address and not include the port number. The company parameter is just used for getVirtualHostname.
- I created anew method that take the portalURL from themeDisplay, and it works right.

Thank you
Hoang

