### PR TITLE
PROMPT 5 Workflow Permissions Forms and Workflow Prompt

### DIFF
--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
@@ -14,12 +14,21 @@
 
 package com.liferay.portal.workflow.task.web.permission;
 
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskAssignee;
+import java.io.Serializable;
+
+import java.util.Map;
 
 /**
  * @author Adam Brandizzi
@@ -37,7 +46,8 @@ public class WorkflowTaskPermissionChecker {
 		}
 
 		if (!permissionChecker.isContentReviewer(
-				permissionChecker.getCompanyId(), groupId)) {
+			permissionChecker.getCompanyId(), groupId) &&
+			!hasAssetViewPermission(permissionChecker, workflowTask)) {
 
 			return false;
 		}
@@ -59,7 +69,31 @@ public class WorkflowTaskPermissionChecker {
 
 		return false;
 	}
+	protected boolean hasAssetViewPermission(
+		PermissionChecker permissionChecker, WorkflowTask workflowTask) {
 
+		Map<String, Serializable> workflowTaskOptionalAttributes =
+			workflowTask.getOptionalAttributes();
+
+		String entryClassName = GetterUtil.getString(
+			workflowTaskOptionalAttributes.get(
+				WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME));
+
+		long entryClassPK = GetterUtil.getLong(
+			workflowTaskOptionalAttributes.get(
+				WorkflowConstants.CONTEXT_ENTRY_CLASS_PK));
+
+		try {
+			WorkflowHandler<?> workflowHandler =
+				WorkflowHandlerRegistryUtil.getWorkflowHandler(entryClassName);
+			AssetRenderer<?> assetRenderer = workflowHandler.getAssetRenderer(
+				entryClassPK);
+			return assetRenderer.hasViewPermission(permissionChecker);
+		}
+		catch (PortalException pe) {
+			return false;
+		}
+	}
 	protected boolean isWorkflowTaskAssignableToRoles(
 		WorkflowTaskAssignee workflowTaskAssignee, long[] roleIds) {
 

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
@@ -20,10 +20,12 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowException;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
@@ -123,9 +125,12 @@ public class MyWorkflowTaskPortlet extends MVCPortlet {
 			WorkflowTask workflowTask, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		long groupId =
+			GetterUtil.getLong(workflowTask.getOptionalAttributes().get(
+				WorkflowConstants.CONTEXT_GROUP_ID));
+
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
-				themeDisplay.getPermissionChecker())) {
+			groupId, workflowTask, themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(
 				String.format(

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/action/AssignTaskMVCActionCommand.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/action/AssignTaskMVCActionCommand.java
@@ -17,9 +17,11 @@ package com.liferay.portal.workflow.task.web.portlet.action;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskManagerUtil;
 import com.liferay.portal.workflow.task.web.permission.WorkflowTaskPermissionChecker;
@@ -49,10 +51,11 @@ public class AssignTaskMVCActionCommand
 
 		WorkflowTask workflowTask = WorkflowTaskManagerUtil.getWorkflowTask(
 			themeDisplay.getCompanyId(), workflowTaskId);
-
+		long groupId =
+			GetterUtil.getLong(workflowTask.getOptionalAttributes().get(
+				WorkflowConstants.CONTEXT_GROUP_ID));
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
-				themeDisplay.getPermissionChecker())) {
+			groupId, workflowTask, themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(
 				String.format(


### PR DESCRIPTION
Hi @binhtran92, 
Please review thís PR for Prompt 5 Workflow Permissions Forms and Workflow Prompt,

Steps to Reproduce using a User with Site Content Reviewer role:
1. Add a new Site "My Site"
2. Add a new User
3. Add User to "My Site"
4. Assign roles: Site Administration and Site Content Reviewer
5. Save User
6. Log in as the new User
7. Go to "My Site"
8. In "My Site" go to Configuration > Workflow Configuration
9. Set Single Approver for Calendar
10. Add a Calendar portlet to a page
11. Add an event > Submit for Publication
12. Go to My Account > Notifications
13. Click on Calendar notification message

Expected Result
User is navigated to My Workflow Tasks portlet to view workflow submission.

Actual Result
The User cannot access My Workflow Tasks portlet. If you navigate back to My Account > My Workflow Tasks > Assigned to My Roles, you are able to access My Workflow Tasks portlet and assign/approve workflow submission but still not view it.

Steps to Reproduce as a User with view permissions:
1. Define the following User role permissions in the Roles portlet
	a. Dynamic Data Lists Record Set: Add Record
	b. Dynamic Data Lists Record Set: Update
	c. Dynamic Data Lists Record Set: View
	d. My Workflow Tasks: Access in My Account
	e. My Workflow Tasks: View
	f. General Permissions: View Control Panel
2. Add a new User with the above role
3. Add DDL Display to a page, then add the "To Do" definition from the display Add button
4. Select Single Approver workflow > Save
5. Log in as the new User
6. Submit a DDL record for publication (attachment not necessary)
7. Log in as Test Test
8. Go to Notifications and select the DDL record submission
9. Assign it to yourself
10. Reject DDL record submission
11. Log in as the new User
12. Go to My Workflow Tasks > Click into rejected DDL record to view details

Expected Result
User is able to view DDL record details.

Actual Result
User gets a permissions error message.

My journey to the solution:
Case 1:
I could see the permission check fail at WorkflowTaskPermissionChecker -> hasPermission
    if (!permissionChecker.isContentReviewer(
           permissionChecker.getCompanyId(), groupId)) {
      return false;
}
keep debuging to AdvancedPermissionChecker -> isContentReviewerImpl(long companyId, long groupId)
and see it return false because user is not content reviewer for groupId.
Go to database to check groupdId 20133 from portal. Group_ and realize it's Control Panel -> not a site groupdId.
GroupId in lportal.KaleoTaskInstanceToken table is different number -> it's site's groupId
My solution is find the right groupdId of WorkflowTask -> get groupdId from WorkflowTask -> OptionalAttributes
Case 2:
The permission check fails at the same place because the user is not Site Admin or Site Reviewer, have to check the user has view permission for a specific asset.
My first thinking about get entryClassName and entryClassPK from WorkflowTask -> OptionalAttributes and pass to
PermissionChecker -> hasPermission(long groupId, String name, String primKey, String actionId); with 'VIEW' action
but it does not work out because groupId, name, primKey don't match.
Go around to find the way to check the VIEW permission of asset from entryClassName and entryClassPK, have found
AssetRenderer assetRenderer = workflowTaskDisplayContext.getAssetRenderer(); from view_content.js and AssetRenderer has method hasViewPermission(PermissionChecker permissionChecker). From WorkflowTaskDisplayContext.java found the way to get AssetRender from WorkflowTask -> Write a new method to check view permission is the solution.

Thank you!
Hoang
