### PR TITLE
[Prompt-2.2] Fix the default results per page and number of folder displayed does not change

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -21,6 +21,7 @@ String navigation = ParamUtil.getString(request, "navigation", "home");
 
 String currentFolder = ParamUtil.getString(request, "curFolder");
 String deltaFolder = ParamUtil.getString(request, "deltaFolder");
+String deltaEntry = ParamUtil.getString(request, "deltaEntry");
 
 long folderId = GetterUtil.getLong((String)request.getAttribute("view.jsp-folderId"));
 
@@ -53,14 +54,14 @@ portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
 
-int defaultDelta;
-if (StringPool.BLANK.equals(deltaFolder)) {
-	defaultDelta = dlPortletInstanceSettings.getEntriesPerPage();
+int delta;
+if (StringPool.BLANK.equals(deltaEntry)) {
+	delta = dlPortletInstanceSettings.getEntriesPerPage();
 } else {
-	defaultDelta = GetterUtil.getInteger(deltaFolder);
+	delta = GetterUtil.getInteger(deltaEntry);
 }
 
-SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", defaultDelta, portletURL, null, null);
+SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", delta, portletURL, null, null);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 

--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_entries.jsp
@@ -53,7 +53,14 @@ portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
 
-SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
+int defaultDelta;
+if (StringPool.BLANK.equals(deltaFolder)) {
+	defaultDelta = dlPortletInstanceSettings.getEntriesPerPage();
+} else {
+	defaultDelta = GetterUtil.getInteger(deltaFolder);
+}
+
+SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", defaultDelta, portletURL, null, null);
 
 EntriesChecker entriesChecker = new EntriesChecker(liferayPortletRequest, liferayPortletResponse);
 
@@ -503,7 +510,7 @@ if (portletTitleBasedNavigation && (folderId != DLFolderConstants.DEFAULT_PARENT
 									actionJspServletContext="<%= application %>"
 									resultRow="<%= row %>"
 									rowChecker="<%= entriesChecker %>"
-									text="<%= HtmlUtil.escape(curFolder.getName()) %>"
+									text="<%= curFolder.getName() %>"
 									url="<%= rowURL.toString() %>"
 								>
 									<liferay-frontend:horizontal-card-col>


### PR DESCRIPTION
- Error: The default results per page and number of folder displayed does not change.
- Cause: `delta` variable represents the number of entries displayed on a page. In JSP code, the default delta did not get the exact value that was updated by the user.
- Resolve: assign the correct default delta value.