### PR TITLE
[Prompt-2.3] Fix cannot publish web content with some old tag names

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,7 +122,7 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
-			AssetTag tag = fetchTag(group.getGroupId(), name);
+			AssetTag tag = fetchTag(group.getGroupId(), StringUtil.toLowerCase(name));
 
 			if (tag == null) {
 				ServiceContext serviceContext = new ServiceContext();

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetTagLocalServiceImpl.java
@@ -122,7 +122,7 @@ public class AssetTagLocalServiceImpl extends AssetTagLocalServiceBaseImpl {
 		List<AssetTag> tags = new ArrayList<>();
 
 		for (String name : names) {
-			AssetTag tag = fetchTag(group.getGroupId(), StringUtil.toLowerCase(name));
+			AssetTag tag = fetchTag(group.getGroupId(), StringUtil.toLowerCase(StringUtil.trim(name)));
 
 			if (tag == null) {
 				ServiceContext serviceContext = new ServiceContext();


### PR DESCRIPTION
- Error: Cannot publish web content with some old tag names
- Cause: The `name` of the `tag` was converted to lowercase before saving it to the database. But when checking `tag` existence, the service fetching `tag` by case sensitive name.
- Resolve: convert the `name` of the `tag` to lowercase before fetching.