### PR TITLE
[Prompt-4.1] Fix 'Calendar is temporarily unavailable' message is shown

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/display/context/CalendarDisplayContext.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/display/context/CalendarDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.calendar.service.CalendarLocalService;
 import com.liferay.calendar.service.CalendarService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 
@@ -47,7 +48,13 @@ public class CalendarDisplayContext {
 		List<Calendar> otherCalendars = new ArrayList<>();
 
 		for (long calendarId : calendarIds) {
-			Calendar calendar = _calendarService.fetchCalendar(calendarId);
+			
+			Calendar calendar = null;
+			try {
+				calendar = _calendarService.fetchCalendar(calendarId);
+			} catch (PrincipalException pe) {
+				continue;
+			}
 
 			if (calendar == null) {
 				continue;


### PR DESCRIPTION
Error: "Calendar is temporarily unavailable" message is shown when a user doesn't have permissions to watch a calendar.
Cause: When the user doesn't have permission to fetch the calendar, `PrincipalException` will be thrown.
Resolve: Catch the exception and return null if occur.