### PR TITLE
[Prompt-3.2] Fix The session-expiration-warning message not show up on 2 windows

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -505,6 +505,7 @@ AUI.add(
 						instance._intervalId = host.registerInterval(
 							function(elapsed, interval, hasWarned, hasExpired, warningMoment, expirationMoment) {
 								if (!hasWarned) {
+									instance._host.extend();
 									instance._uiSetActivated();
 								}
 								else if (!hasExpired) {


### PR DESCRIPTION
- Error: The session-expiration-warning message will show up on the main page and a pop-up page in its first iteration, but after the "extend the session" button is pressed on one of the windows (either pop-up or main), the message will not appear on the other window when the warning is displayed a second time.
- Cause: Opening 2 windows First and Second. At first warning, both window change `sessionState` from active to warned timer `processing. _onHostSessionStateChange` is trigger and warning banner is showed. Click Extend button on First page. the `sessionState` of First page will change from warned to active, and warning banner will be closed. On Second page will also closed warning banner but not change `sesstionState` from warned back to active. At the next warning, Second page will not trigger `_onHostSessionStateChange` for showing warning banner. 
- Resolve: change `sessionState` to active whenever warning banner closed by extending session. add this code `instance._host.extend();`