### PR TITLE
[Prompt-4.2] Fix The application server's port is exposed

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4988,13 +4988,51 @@ public class PortalImpl implements Portal {
 
 		StringBundler sb = new StringBundler(7);
 
-		if (company != null) {			
-			sb.append(
-					getPortalURL(
-							company.getVirtualHostname(), getPortalServerPort(false),
-							false));
+		sb.append(
+			getPortalURL(
+				company.getVirtualHostname(), getPortalServerPort(false),
+				false));
+
+		sb.append(getPathFriendlyURLPrivateGroup());
+
+		if ((group != null) && !group.isControlPanel()) {
+			sb.append(group.getFriendlyURL());
+			sb.append(VirtualLayoutConstants.CANONICAL_URL_SEPARATOR);
 		}
 
+		sb.append(GroupConstants.CONTROL_PANEL_FRIENDLY_URL);
+		sb.append(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL);
+
+		if (params != null) {
+			params = new LinkedHashMap<>(params);
+		}
+		else {
+			params = new LinkedHashMap<>();
+		}
+
+		if (Validator.isNotNull(ppid)) {
+			params.put("p_p_id", new String[] {ppid});
+		}
+
+		params.put("p_p_lifecycle", new String[] {"0"});
+		params.put(
+			"p_p_state", new String[] {WindowState.MAXIMIZED.toString()});
+		params.put("p_p_mode", new String[] {PortletMode.VIEW.toString()});
+
+		sb.append(HttpUtil.parameterMapToString(params, true));
+
+		return sb.toString();
+	}
+	
+	@Override
+	public String getSiteAdminURL(ThemeDisplay themeDisplay, Company company, Group group, String ppid,
+			Map<String, String[]> params) throws PortalException {
+		
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(themeDisplay.getPortalURL());
+		sb.append(StringPool.SLASH);
+				
 		sb.append(getPathFriendlyURLPrivateGroup());
 
 		if ((group != null) && !group.isControlPanel()) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -4988,10 +4988,12 @@ public class PortalImpl implements Portal {
 
 		StringBundler sb = new StringBundler(7);
 
-		sb.append(
-			getPortalURL(
-				company.getVirtualHostname(), getPortalServerPort(false),
-				false));
+		if (company != null) {			
+			sb.append(
+					getPortalURL(
+							company.getVirtualHostname(), getPortalServerPort(false),
+							false));
+		}
 
 		sb.append(getPathFriendlyURLPrivateGroup());
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -1084,6 +1084,16 @@ public interface Portal {
 			Map<String, String[]> params)
 		throws PortalException;
 
+
+	public String getSiteAdminURL(ThemeDisplay themeDisplay,
+			Company company, Group group, String ppid,
+			Map<String, String[]> params)
+		throws PortalException;
+
+	/**
+	 * @deprecated As of 7.0.0, replaced by {@link #getSiteAdminURL(ThemeDisplay, Company,
+	 *             Group, String, Map)}
+	 */
 	/**
 	 * @deprecated As of 7.0.0, replaced by {@link #getSiteAdminURL(Company,
 	 *             Group, String, Map)}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1750,11 +1750,20 @@ public class PortalUtil {
 	}
 
 	public static String getSiteAdminURL(
+			Company company, Group group, String ppid,
+			Map<String, String[]> params)
+		throws PortalException {
+
+		return getPortal().getSiteAdminURL(company, group, ppid, params);
+	}
+
+	public static String getSiteAdminURL(
 			ThemeDisplay themeDisplay, Group group, String ppid,
 			Map<String, String[]> params)
 		throws PortalException {
-		Portal portal = getPortal();
-		return themeDisplay.getPortalURL() + portal.getSiteAdminURL(null, group, ppid, params);
+		
+		return getPortal().getSiteAdminURL(themeDisplay, themeDisplay.getCompany(),
+				group, ppid, params);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -1750,11 +1750,11 @@ public class PortalUtil {
 	}
 
 	public static String getSiteAdminURL(
-			Company company, Group group, String ppid,
+			ThemeDisplay themeDisplay, Group group, String ppid,
 			Map<String, String[]> params)
 		throws PortalException {
-
-		return getPortal().getSiteAdminURL(company, group, ppid, params);
+		Portal portal = getPortal();
+		return themeDisplay.getPortalURL() + portal.getSiteAdminURL(null, group, ppid, params);
 	}
 
 	/**

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -248,7 +248,7 @@
 				return '<%= PropsValues.SESSION_ENABLE_URL_WITH_SESSION_ID ? session.getId() : StringPool.BLANK %>';
 			},
 			getSiteAdminURL: function() {
-				return '<%= PortalUtil.getSiteAdminURL(themeDisplay.getCompany(), themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
+				return '<%= PortalUtil.getSiteAdminURL(themeDisplay, themeDisplay.getScopeGroup(), StringPool.BLANK, null) %>';
 			},
 			getSiteGroupId: function() {
 				return '<%= themeDisplay.getSiteGroupId() %>';


### PR DESCRIPTION
Error: Setting `web.server.protocol=https` or `web.server.protocol=http` in `portal-ext.properties` will expose the Application Server's port in the source of the default landing page.
Cause: The service use the wrong method to get the server host and port
Resolve: Change the method to `getPortalURL` to get the host and port. This is maybe a work-around solution. I can fix it another way. Please give me your feedback. thanks