### PR TITLE
[Prompt-5] Fix User does not have permission to navigate to workflow submission and view DDL record details.

### DIFF
--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/permission/WorkflowTaskPermissionChecker.java
@@ -14,12 +14,23 @@
 
 package com.liferay.portal.workflow.task.web.permission;
 
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
 import com.liferay.portal.kernel.workflow.WorkflowTask;
 import com.liferay.portal.kernel.workflow.WorkflowTaskAssignee;
+
+import java.io.Serializable;
+import java.util.Map;
 
 /**
  * @author Adam Brandizzi
@@ -36,8 +47,9 @@ public class WorkflowTaskPermissionChecker {
 			return true;
 		}
 
-		if (!permissionChecker.isContentReviewer(
-				permissionChecker.getCompanyId(), groupId)) {
+		if (!hasAssetViewPermission(workflowTask, permissionChecker) && 
+				!permissionChecker.isContentReviewer(
+						permissionChecker.getCompanyId(), groupId)) {
 
 			return false;
 		}
@@ -55,6 +67,34 @@ public class WorkflowTaskPermissionChecker {
 
 				return true;
 			}
+		}
+
+		return false;
+	}
+
+	protected boolean hasAssetViewPermission(WorkflowTask workflowTask, 
+			PermissionChecker permissionChecker) {
+
+		Map<String, Serializable> optionalAttributes = workflowTask.getOptionalAttributes();
+
+		String className = MapUtil.getString(optionalAttributes, 
+				WorkflowConstants.CONTEXT_ENTRY_CLASS_NAME);
+		long classPK = MapUtil.getLong(optionalAttributes, 
+				WorkflowConstants.CONTEXT_ENTRY_CLASS_PK);
+
+		WorkflowHandler<?> workflowHandler = 
+				WorkflowHandlerRegistryUtil.getWorkflowHandler(className);
+
+		if (workflowHandler == null) {
+			return false;
+		}
+
+		try {
+			AssetRenderer<?> assetRenderer = workflowHandler.getAssetRenderer(classPK);
+
+			return assetRenderer.hasViewPermission(permissionChecker);
+		} catch (PortalException pe) {
+			_log.error(pe, pe);
 		}
 
 		return false;
@@ -94,4 +134,6 @@ public class WorkflowTaskPermissionChecker {
 		return false;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+			WorkflowTaskPermissionChecker.class);
 }

--- a/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
+++ b/modules/apps/forms-and-workflow/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/portlet/MyWorkflowTaskPortlet.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -31,7 +32,6 @@ import com.liferay.portal.workflow.task.web.configuration.WorkflowTaskWebConfigu
 import com.liferay.portal.workflow.task.web.permission.WorkflowTaskPermissionChecker;
 
 import java.io.IOException;
-
 import java.util.Map;
 
 import javax.portlet.ActionRequest;
@@ -123,8 +123,12 @@ public class MyWorkflowTaskPortlet extends MVCPortlet {
 			WorkflowTask workflowTask, ThemeDisplay themeDisplay)
 		throws PortalException {
 
+		long groupId = MapUtil.getLong(
+				workflowTask.getOptionalAttributes(), "groupId",
+				themeDisplay.getSiteGroupId());
+		
 		if (!_workflowTaskPermissionChecker.hasPermission(
-				themeDisplay.getScopeGroupId(), workflowTask,
+				groupId, workflowTask,
 				themeDisplay.getPermissionChecker())) {
 
 			throw new PrincipalException(


### PR DESCRIPTION
- Error: User does not have permission to navigate to workflow submission and view DDL record details. 
The User cannot access the My Workflow Tasks portlet to view. and also gets a permissions error message when clicking to view rejected DDL record submission. 
- Cause: 1. The method `MyWorkflowTaskPortlet::checkWorkflowTaskViewPermission` uses incorrect `groupId`. It must be `groupId` from `WorkTask` `_optionalAttributes`    
2. According to my opinion, at `WorkflowTaskPermissionChecker::hasPermission` line 50, 
the service just check the role of user Site Admin or Site Content Reviewer with `isContentReviewer`. 
We need to combine to check permission of asset render (`BaseJSPAssetRenderer`) on the site.
- Resolve: We use the method `AssetRenderer::hasViewPermission` to check permission to view of the user. And change the resource of `groupId`